### PR TITLE
Fix to the code that constructs the response URL for idp redirection

### DIFF
--- a/saml2-core/src/main/java/org/springframework/security/saml/SAMLDiscovery.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/SAMLDiscovery.java
@@ -232,15 +232,16 @@ public class SAMLDiscovery extends GenericFilterBean {
      */
     protected void sendPassiveResponse(HttpServletRequest request, HttpServletResponse response, String responseURL, String returnParam, String entityID) throws IOException, ServletException {
 
+        String finalResponseURL = responseURL;
         if (entityID != null) {
             URLBuilder urlBuilder = new URLBuilder(responseURL);
             List<Pair<String, String>> queryParams = urlBuilder.getQueryParams();
             queryParams.add(new Pair<String, String>(returnParam, entityID));
-            responseURL = urlBuilder.toString();
+            finalResponseURL = urlBuilder.buildURL();
         }
 
-        logger.debug("Responding to a passive IDP Discovery request with URL {}", responseURL);
-        response.sendRedirect(responseURL);
+        logger.debug("Responding to a passive IDP Discovery request with URL {}", finalResponseURL);
+        response.sendRedirect(finalResponseURL);
 
     }
 


### PR DESCRIPTION
The code was invoking urlBuilder.toString() that returns the name of the class instead of the actual url.
