### PR TITLE
Support for stateless operation.

### DIFF
--- a/saml2-core/src/main/java/org/springframework/security/saml/SAMLAuthenticationToken.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/SAMLAuthenticationToken.java
@@ -44,8 +44,8 @@ public class SAMLAuthenticationToken extends AbstractAuthenticationToken {
 
         super(null);
 
-        if (credentials == null || messageStore == null) {
-            throw new IllegalArgumentException("SAMLAuthenticationToken requires both credentials and messageStore parameters to be set");
+        if (credentials == null) {
+            throw new IllegalArgumentException("SAMLAuthenticationToken requires the credentials parameter to be set");
         }
 
         this.credentials = credentials;

--- a/saml2-core/src/main/java/org/springframework/security/saml/SAMLEntryPoint.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/SAMLEntryPoint.java
@@ -198,7 +198,7 @@ public class SAMLEntryPoint extends GenericFilterBean implements AuthenticationE
     protected void initializeSSO(SAMLMessageContext context, AuthenticationException e) throws MetadataProviderException, SAMLException, MessageEncodingException {
 
         HttpServletRequest request = ((HttpServletRequestAdapter) context.getInboundMessageTransport()).getWrappedRequest();
-        SAMLMessageStorage storage = new HttpSessionStorage(request);
+        SAMLMessageStorage storage = newHttpSessionStorage(request);
         WebSSOProfileOptions options = getProfileOptions(context, e);
 
         // Determine the assertionConsumerService to be used
@@ -221,6 +221,13 @@ public class SAMLEntryPoint extends GenericFilterBean implements AuthenticationE
         webSSOprofile.sendAuthenticationRequest(context, options, storage);
         samlLogger.log(SAMLConstants.AUTH_N_REQUEST, SAMLConstants.SUCCESS, context, e);
 
+    }
+
+    /**
+     * Create a new HttpSessionStorage object, or <code>null<code> if no HTTP session should be used.
+     */
+    protected HttpSessionStorage newHttpSessionStorage(HttpServletRequest request) {
+        return new HttpSessionStorage(request);
     }
 
     /**

--- a/saml2-core/src/main/java/org/springframework/security/saml/SAMLProcessingFilter.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/SAMLProcessingFilter.java
@@ -81,7 +81,7 @@ public class SAMLProcessingFilter extends AbstractAuthenticationProcessingFilter
             context.setCommunicationProfileId(getProfileName());
             context.setLocalEntityEndpoint(SAMLUtil.getEndpoint(context.getLocalEntityRoleMetadata().getEndpoints(), context.getInboundSAMLBinding(), getFilterProcessesUrl()));
 
-            HttpSessionStorage storage = new HttpSessionStorage(request);
+            HttpSessionStorage storage = newHttpSessionStorage(request);
             SAMLAuthenticationToken token = new SAMLAuthenticationToken(context, storage);
             return getAuthenticationManager().authenticate(token);
 
@@ -95,6 +95,13 @@ public class SAMLProcessingFilter extends AbstractAuthenticationProcessingFilter
             throw new SAMLRuntimeException("Incoming SAML message is invalid", e);
         }
 
+    }
+
+    /**
+     * Create a new HttpSessionStorage object, or <code>null<code> if no HTTP session should be used.
+     */
+    protected HttpSessionStorage newHttpSessionStorage(HttpServletRequest request) {
+        return new HttpSessionStorage(request);
     }
 
     /**

--- a/saml2-core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileConsumerImpl.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileConsumerImpl.java
@@ -54,6 +54,8 @@ public class WebSSOProfileConsumerImpl extends AbstractProfileBase implements We
 
     private final static Logger log = LoggerFactory.getLogger(WebSSOProfileConsumerImpl.class);
 
+    private boolean validateResponseAgainstRequest = true;
+
     public WebSSOProfileConsumerImpl() {
     }
 
@@ -121,7 +123,7 @@ public class WebSSOProfileConsumerImpl extends AbstractProfileBase implements We
         }
 
         // Verify response to field if present, set request if correct
-        if (response.getInResponseTo() != null) {
+        if (validateResponseAgainstRequest && response.getInResponseTo() != null) {
             XMLObject xmlObject = protocolCache.retrieveMessage(response.getInResponseTo());
             if (xmlObject == null) {
                 log.debug("InResponseToField doesn't correspond to sent message", response.getInResponseTo());
@@ -586,6 +588,24 @@ public class WebSSOProfileConsumerImpl extends AbstractProfileBase implements We
 
         }
 
+    }
+
+    /**
+     * Whether or not to validate the response 'in-response-to' data against the original request. Defaults to true.
+     * If true, session state will be used to store the original requset data. If false, session state can be avoided,
+     * but replay attacks and DoS attacks should be taken into consideration.
+     */
+    public boolean getValidateResponseAgainstRequest() {
+        return validateResponseAgainstRequest;
+    }
+
+    /**
+     * Sets whether or not to validate the response 'in-response-to' data against the original request. Defaults to true.
+     * If true, session state will be used to store the original requset data. If false, session state can be avoided,
+     * but replay attacks and DoS attacks should be taken into consideration.
+     */
+    public void setValidateResponseAgainstRequest(boolean validate) {
+        this.validateResponseAgainstRequest = validate;
     }
 
     /**

--- a/saml2-core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileImpl.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileImpl.java
@@ -100,7 +100,9 @@ public class WebSSOProfileImpl extends AbstractProfileBase implements WebSSOProf
 
         boolean sign = spDescriptor.isAuthnRequestsSigned() || idpssoDescriptor.getWantAuthnRequestsSigned();
         sendMessage(context, sign);
-        messageStorage.storeMessage(authRequest.getID(), authRequest);
+        
+        if (messageStorage != null)
+            messageStorage.storeMessage(authRequest.getID(), authRequest);
 
     }
 

--- a/saml2-core/src/test/java/org/springframework/security/saml/SAMLAuthenticationTokenTest.java
+++ b/saml2-core/src/test/java/org/springframework/security/saml/SAMLAuthenticationTokenTest.java
@@ -63,9 +63,9 @@ public class SAMLAuthenticationTokenTest {
     }
 
     /**
-     * Verifies that the token can't be created without context.
+     * Verifies that the token can be created without context.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWithoutStorage() {
         token = new SAMLAuthenticationToken(new SAMLMessageContext(), null);
     }


### PR DESCRIPTION
Add overridable methods and configuration properties so that WebSSO
service providers can avoid session state. This has only been validated
with the WebSSO profile -- HoK and ECP profiles might still require
statefulness, or expect session state data structures to be available.

Note that avoiding session state implies that you are using an alternate
means to validate SAML return info (e.g., hashes in cookies), or are
comfortable with the potential DoS and replay-attack risks involved.
