### PR TITLE
Added option for setting Metadata ID separately from entityID for Metada...

### DIFF
--- a/saml2-core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
@@ -61,6 +61,7 @@ import java.util.*;
  */
 public class MetadataGenerator {
 
+    private String id;
     private String entityId;
     private String entityBaseURL;
     private String entityAlias;
@@ -183,7 +184,11 @@ public class MetadataGenerator {
 
         SAMLObjectBuilder<EntityDescriptor> builder = (SAMLObjectBuilder<EntityDescriptor>) builderFactory.getBuilder(EntityDescriptor.DEFAULT_ELEMENT_NAME);
         EntityDescriptor descriptor = builder.buildObject();
-        descriptor.setID(entityId);
+        if (id != null) {
+            descriptor.setID(id);
+        } else {
+            descriptor.setID(entityId);
+        }
         descriptor.setEntityID(entityId);
         descriptor.getRoleDescriptors().add(buildSPSSODescriptor(entityBaseURL, entityAlias, requestSigned, assertionSigned, includedNameID));
 
@@ -710,6 +715,14 @@ public class MetadataGenerator {
 
     public void setEncryptionKey(String encryptionKey) {
         this.encryptionKey = encryptionKey;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public void setEntityId(String entityId) {

--- a/saml2-core/src/test/java/org/springframework/security/saml/metadata/MetadataGeneratorTest.java
+++ b/saml2-core/src/test/java/org/springframework/security/saml/metadata/MetadataGeneratorTest.java
@@ -56,6 +56,7 @@ public class MetadataGeneratorTest {
         generator.setIncludeDiscoveryExtension(true);
         EntityDescriptor metadata = generator.generateMetadata();
 
+        assertEquals("my_entity", metadata.getID());
         assertEquals("my_entity", metadata.getEntityID());
         SPSSODescriptor spssoDescriptor = metadata.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
         assertNotNull(spssoDescriptor);
@@ -92,6 +93,22 @@ public class MetadataGeneratorTest {
         assertEquals(2, nameID.size());
         assertEquals(NameIDType.TRANSIENT, nameID.get(0).getFormat());
         assertEquals(NameIDType.EMAIL, nameID.get(1).getFormat());
+
+    }
+
+    /**
+     * Test verifies that metadata ID and EntityId can be set independently.
+     */
+    @Test
+    public void testSettingIdAndEntityIdIndependently() {
+
+        generator.setEntityBaseURL("http://localhost");
+        generator.setId("my_id");
+        generator.setEntityId("my_entity");
+        EntityDescriptor metadata = generator.generateMetadata();
+
+        assertEquals("my_id", metadata.getID());
+        assertEquals("my_entity", metadata.getEntityID());
 
     }
 


### PR DESCRIPTION
...taGenerator.

This is useful for some IdPs that allow an URL for entityId but ID can only contain a-zA-Z0-9_. 
