### PR TITLE
ArtifactResolution's http client is now thread safe

### DIFF
--- a/saml2-sample/src/main/resources/security/securityContext.xml
+++ b/saml2-sample/src/main/resources/security/securityContext.xml
@@ -223,7 +223,11 @@
         <constructor-arg>
             <bean class="org.springframework.security.saml.websso.ArtifactResolutionProfileImpl">
                 <constructor-arg>
-                    <bean class="org.apache.commons.httpclient.HttpClient"/>
+                    <bean class="org.apache.commons.httpclient.HttpClient">
+                        <constructor-arg>
+                            <bean class="org.apache.commons.httpclient.MultiThreadedHttpConnectionManager"/>
+                        </constructor-arg>
+                    </bean>
                 </constructor-arg>
                 <property name="processor">
                     <bean id="soapProcessor" class="org.springframework.security.saml.processor.SAMLProcessorImpl">


### PR DESCRIPTION
 I ran into some race conditions, using this example config. HttpClient is not thread safe by default, so I had to change its constructor. 
