### PR TITLE
Fixed case of property name in the call to action

### DIFF
--- a/saml2-core/src/main/java/org/springframework/security/saml/metadata/MetadataGeneratorFilter.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/metadata/MetadataGeneratorFilter.java
@@ -119,7 +119,7 @@ public class MetadataGeneratorFilter extends GenericFilterBean {
 
                         // Use default baseURL if not set
                         if (generator.getEntityBaseURL() == null) {
-                            log.warn("Generated default entity base URL {} based on values in the first server request. Please set property entityBaseUrl on MetadataGenerator bean to fixate the value.", baseURL);
+                            log.warn("Generated default entity base URL {} based on values in the first server request. Please set property entityBaseURL on MetadataGenerator bean to fixate the value.", baseURL);
                             generator.setEntityBaseURL(baseURL);
                         } else {
                             baseURL = generator.getEntityBaseURL();


### PR DESCRIPTION
When running the sample the log will ask you to set entityBaseUrl. That
property does not exist (it's entityBaseURL.)
