### PR TITLE
Configured Proxy was not used in ArtifactResolutionProfile while creating the HostConfiguration

### DIFF
--- a/saml2-core/src/main/java/org/springframework/security/saml/websso/ArtifactResolutionProfileImpl.java
+++ b/saml2-core/src/main/java/org/springframework/security/saml/websso/ArtifactResolutionProfileImpl.java
@@ -81,7 +81,7 @@ public class ArtifactResolutionProfileImpl extends ArtifactResolutionProfileBase
             postMethod = new PostMethod();
             postMethod.setPath(uri.getPath());
 
-            HostConfiguration hc = getHostConfiguration(uri, context);
+            HostConfiguration hc = getHostConfiguration(uri, context, httpClient.getHostConfiguration());
 
             HttpClientOutTransport clientOutTransport = new HttpClientOutTransport(postMethod);
             HttpClientInTransport clientInTransport = new HttpClientInTransport(postMethod, endpointURI);
@@ -131,10 +131,11 @@ public class ArtifactResolutionProfileImpl extends ArtifactResolutionProfileBase
      *
      * @param uri uri the request should be sent to
      * @param context context including the peer address
+     * @param hostConfiguration A host configuration that may also contain a proxy server configuration.
      * @return host configuration
      * @throws MessageEncodingException in case peer URI can't be parsed
      */
-    protected HostConfiguration getHostConfiguration(URI uri, SAMLMessageContext context) throws MessageEncodingException {
+    protected HostConfiguration getHostConfiguration(URI uri, SAMLMessageContext context, HostConfiguration hostConfiguration) throws MessageEncodingException {
 
         try {
 
@@ -158,6 +159,12 @@ public class ArtifactResolutionProfileImpl extends ArtifactResolutionProfileBase
                 X509KeyManager manager = new X509KeyManager(context.getLocalSSLCredential());
                 Protocol protocol = new Protocol("https", (ProtocolSocketFactory) new TLSProtocolSocketFactory(manager, trustManager), 443);
                 hc.setHost(uri.getHost(), uri.getPort(), protocol);
+
+                /*
+                 * Use the proxy server from the host configuration, if configured.
+                */
+                if (hostConfiguration.getProxyHost() != null)
+                    hc.setProxy(hostConfiguration.getProxyHost(), hostConfiguration.getProxyPort());
 
             }
 


### PR DESCRIPTION
Hi Vladimír,

First of all: thank you for your awesome work on this project!

I have found and fixed a small but critical bug where the proxy server configured in `springSecurity.xml` into an `HttpClient` bean is not used when `ArtifactResolutionProfileImpl` creates a new `HostConfiguration` in the method `getHostConfiguration`. This leads to the post-login authentication steps to fail if the application is deployed behind a proxy server.

Kind Regards
Rias
