### PR TITLE
Add RequesterID support in the Scoping section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 .classpath
 .project
 .gradle
+classes

--- a/core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileImpl.java
+++ b/core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileImpl.java
@@ -19,6 +19,7 @@ import org.opensaml.common.SAMLObjectBuilder;
 import org.opensaml.common.SAMLRuntimeException;
 import org.opensaml.common.SAMLVersion;
 import org.opensaml.saml2.core.*;
+import org.opensaml.saml2.core.impl.RequesterIDBuilder;
 import org.opensaml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml2.metadata.SPSSODescriptor;
@@ -31,6 +32,7 @@ import org.springframework.security.saml.metadata.ExtendedMetadata;
 import org.springframework.security.saml.metadata.MetadataManager;
 import org.springframework.security.saml.processor.SAMLProcessor;
 import org.springframework.security.saml.storage.SAMLMessageStorage;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Collection;
 import java.util.List;
@@ -363,7 +365,19 @@ public class WebSSOProfileImpl extends AbstractProfileBase implements WebSSOProf
             Scoping scoping = scopingBuilder.buildObject();
             scoping.setIDPList(idpList);
             scoping.setProxyCount(options.getProxyCount());
+
+            if (!CollectionUtils.isEmpty(options.getRequesterIds())) {
+                RequesterIDBuilder requesterIDBuilder = new RequesterIDBuilder();
+                for (String id : options.getRequesterIds()) {
+                    RequesterID requesterID = requesterIDBuilder.buildObject();
+                    requesterID.setRequesterID(id);
+                    scoping.getRequesterIDs().add(requesterID);
+                }
+            }
+
             request.setScoping(scoping);
+
+
 
         }
 

--- a/core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileOptions.java
+++ b/core/src/main/java/org/springframework/security/saml/websso/WebSSOProfileOptions.java
@@ -44,6 +44,8 @@ public class WebSSOProfileOptions implements Serializable, Cloneable {
     private Collection<String> authnContexts;
     private AuthnContextComparisonTypeEnumeration authnContextComparison = AuthnContextComparisonTypeEnumeration.EXACT;
 
+    private Set<String> requesterIds;
+
     public WebSSOProfileOptions() {
     }
 
@@ -271,4 +273,20 @@ public class WebSSOProfileOptions implements Serializable, Cloneable {
         this.relayState = relayState;
     }
 
+    public Set<String> getRequesterIds() {
+        return requesterIds;
+    }
+
+    /**
+     * Identifies the set of requesting entities on whose behalf the requester is acting. Used to communicate
+     * the chain of requesters when proxying occurs.
+     * <p>
+     * Property includeScoping must be enabled for this value to take any effect.
+     * </p>
+     *
+     * @param requesterIds the names of the requester
+     */
+    public void setRequesterIds(Set<String> requesterIds) {
+        this.requesterIds = requesterIds;
+    }
 }


### PR DESCRIPTION
The SAML specification supports the RequesterID element to identify the set of requesting entities
on whose behalf the requester is acting. Used to communicate the chain of requesters when proxying
occurs. The org.opensaml:opensaml:2.6.1 library supports this, but there was no option in WebSSOProfileOptions
to set the RequesterID.

See also: https://jira.spring.io/browse/SES-171
