### PR TITLE
Update SAMLAuthenticationProvider.java

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/SAMLAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/saml/SAMLAuthenticationProvider.java
@@ -91,23 +91,23 @@ public class SAMLAuthenticationProvider implements AuthenticationProvider, Initi
                 throw new SAMLException("Unsupported profile encountered in the context " + context.getCommunicationProfileId());
             }
         } catch (SAMLRuntimeException e) {
-            log.debug("Error validating SAML message", e);
+            log.error("Error validating SAML message", e);
             samlLogger.log(SAMLConstants.AUTH_N_RESPONSE, SAMLConstants.FAILURE, context, e);
             throw new AuthenticationServiceException("Error validating SAML message", e);
         } catch (SAMLException e) {
-            log.debug("Error validating SAML message", e);
+            log.error("Error validating SAML message", e);
             samlLogger.log(SAMLConstants.AUTH_N_RESPONSE, SAMLConstants.FAILURE, context, e);
             throw new AuthenticationServiceException("Error validating SAML message", e);
         } catch (ValidationException e) {
-            log.debug("Error validating signature", e);
+            log.error("Error validating signature", e);
             samlLogger.log(SAMLConstants.AUTH_N_RESPONSE, SAMLConstants.FAILURE, context, e);
             throw new AuthenticationServiceException("Error validating SAML message signature", e);
         } catch (org.opensaml.xml.security.SecurityException e) {
-            log.debug("Error validating signature", e);
+            log.error("Error validating signature", e);
             samlLogger.log(SAMLConstants.AUTH_N_RESPONSE, SAMLConstants.FAILURE, context, e);
             throw new AuthenticationServiceException("Error validating SAML message signature", e);
         } catch (DecryptionException e) {
-            log.debug("Error decrypting SAML message", e);
+            log.error("Error decrypting SAML message", e);
             samlLogger.log(SAMLConstants.AUTH_N_RESPONSE, SAMLConstants.FAILURE, context, e);
             throw new AuthenticationServiceException("Error decrypting SAML message", e);
         }


### PR DESCRIPTION
We have to turn on the DEBUG mode in the logger to get the exception stack trace. So proposing to change the exceptions to log.error.
