### PR TITLE
Specify security schema version explicitly.

### DIFF
--- a/sample/src/main/webapp/WEB-INF/securityContext.xml
+++ b/sample/src/main/webapp/WEB-INF/securityContext.xml
@@ -4,7 +4,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+              http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
     <!-- Enable auto-wiring -->
     <context:annotation-config/>


### PR DESCRIPTION
Right now, http://www.springframework.org/schema/security/spring-security.xsd is
pointing to version 4.0, while the project is actually using version 3.1.