### PR TITLE
Uses joda time and time zones to check if time skew is valid.

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/util/SAMLUtil.java
+++ b/core/src/main/java/org/springframework/security/saml/util/SAMLUtil.java
@@ -16,6 +16,7 @@
 package org.springframework.security.saml.util;
 
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 import org.opensaml.common.SAMLException;
 import org.opensaml.common.SAMLRuntimeException;
 import org.opensaml.common.binding.decoding.BasicURLComparator;
@@ -481,8 +482,12 @@ public class SAMLUtil {
      * @return true if time matches, false otherwise
      */
     public static boolean isDateTimeSkewValid(int skewInSec, long forwardInterval, DateTime time) {
-        long reference = System.currentTimeMillis();
-        return time.isBefore(reference + (skewInSec * 1000)) && time.isAfter(reference - ((skewInSec + forwardInterval) * 1000));
+        final DateTime reference = new DateTime();
+        final Interval validTimeInterval = new Interval(
+                reference.minusSeconds(skewInSec + (int)forwardInterval),
+                reference.plusSeconds(skewInSec)
+        );
+        return validTimeInterval.contains(time);
     }
 
     /**


### PR DESCRIPTION
The original check ignored timezones and therefore did not work on my UTC+2 machine with a UTC+0 server. This small change should fix it.
