### PR TITLE
Update SSO Circle metaAlias

### DIFF
--- a/docs/reference/docbook/quick-start.xml
+++ b/docs/reference/docbook/quick-start.xml
@@ -181,7 +181,7 @@
 		<para>Pressing local logout will destroy local session and logout the user. While a session is still active at the IDP an attempt to reauthenticate
 		will proceed without need to enter credentials.</para>
 		<para>Pressing global logout will destroy both local session and the session at IDP.</para>
-		<para>You can test IDP initialized single sign-on with URL <emphasis>https://idp.ssocircle.com:443/sso/saml2/jsp/idpSSOInit.jsp?metaAlias=/ssocircle&amp;spEntityID=replaceWithUniqueIdentifier</emphasis>, after replacing
+		<para>You can test IDP initialized single sign-on with URL <emphasis>https://idp.ssocircle.com:443/sso/saml2/jsp/idpSSOInit.jsp?metaAlias=/publicidp&amp;spEntityID=replaceWithUniqueIdentifier</emphasis>, after replacing
 		the service provider identifier with the one configured as entityId in your securityContext.xml. It is possible to provide relayState data sent to your SP with parameter <emphasis>RelayState</emphasis>.</para>
 	</section>
 </chapter>


### PR DESCRIPTION
This quick start guide references a deprecated metaAlias, which causes IDP-initiated SSO to fail. The correct alias is `publicidp`.