### PR TITLE
SAMLContextProviderImpl: getDefaultLocalEntityId & getDefaultLocalEntityRole

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/context/SAMLContextProviderImpl.java
+++ b/core/src/main/java/org/springframework/security/saml/context/SAMLContextProviderImpl.java
@@ -286,11 +286,33 @@ public class SAMLContextProviderImpl implements SAMLContextProvider, Initializin
 
         } else { // Defaults
 
-            context.setLocalEntityId(metadata.getHostedSPName());
-            context.setLocalEntityRole(SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+            context.setLocalEntityId(getDefaultLocalEntityId(context, requestURI));
+            context.setLocalEntityRole(getDefaultLocalEntityRole(context, requestURI));
 
         }
 
+    }
+
+    /**
+     * Returns localEntityId to be populated for the context in case alias is missing from the path
+     * @param context context to retrieve localEntityId for
+     * @param requestURI context path to parse entityId from
+     * @return localEntityId
+     * @throws MetadataProviderException in case entityId can't be retrieved
+     */
+    protected String getDefaultLocalEntityId(SAMLMessageContext context, String requestURI) throws MetadataProviderException {
+        return metadata.getHostedSPName();
+    }
+
+    /**
+     * Returns localEntityRole to be populated for the context in case alias is missing from the path
+     * @param context context to retrieve localEntityRole for
+     * @param requestURI context path to parse entityRole from
+     * @return localEntityRole
+     * @throws MetadataProviderException in case entityRole can't be retrieved
+     */
+    protected QName getDefaultLocalEntityRole(SAMLMessageContext context, String requestURI) throws MetadataProviderException {
+        return SPSSODescriptor.DEFAULT_ELEMENT_NAME;
     }
 
     /**


### PR DESCRIPTION
Sometimes the default multi-tenancy machinery with `/alias/` is not an option, but some flexibility is still required.