### PR TITLE
Remove unreachable/duplicate statement

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/SAMLAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/saml/SAMLAuthenticationToken.java
@@ -42,7 +42,6 @@ public class SAMLAuthenticationToken extends AbstractAuthenticationToken {
         super(null);
 
         Assert.notNull(credentials, "SAMLAuthenticationToken requires the credentials parameter to be set");
-        Assert.notNull(credentials, "SAMLAuthenticationToken requires the message storage parameter to be set");
 
         this.credentials = credentials;
 


### PR DESCRIPTION
Both `Assert.notNull()` calls are on the `credentials` argument.

This was introduced in b8a14120c89a20a41d382cb1b25e335dd0a3d38c
when the messageStore was factored out