### PR TITLE
Don't append / when entityBaseURL ends with /

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
+++ b/core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
@@ -502,7 +502,7 @@ public class MetadataGenerator {
 
         StringBuilder result = new StringBuilder();
         result.append(entityBaseURL);
-        if (!processingURL.startsWith("/")) {
+        if (!processingURL.startsWith("/") && entityBaseURL.endsWith("/")) {
             result.append("/");
         }
         result.append(processingURL);


### PR DESCRIPTION
If entityBaseURL ends with /, and processingURL starts with a / (as can easily happen due to reasonable configuration expectations), getServerURL will return an invalid URL. This change fixes the double-/ that is introduced.

This issue was discovered as I used spring-boot-security-saml, see https://github.com/ulisesbocchio/spring-boot-security-saml/issues/63