### PR TITLE
SAMLCredential / SAMLObject greater than 64k (0xFFFFL) throws UTFDataFormatException

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.4.PATCH.BUILD-SNAPSHOT</version>
+  <version>1.0.4.BUILD-SNAPSHOT</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>
@@ -247,17 +247,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <distributionManagement>
-    <repository>
-      <id>repository-releases</id>
-      <name>repository-releases</name>
-      <url>http://mvn-repo.kamodata.be/nexus/content/repositories/EVA-Maven2-Repository-Releases/</url>
-    </repository>
-    <snapshotRepository>
-      <id>repository-snapshots</id>
-      <name>repository-snapshots</name>
-      <url>http://mvn-repo.kamodata.be/nexus/content/repositories/EVA-Maven2-Repository-Snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.4.PATCH1.RELEASE-SNAPSHOT</version>
+  <version>1.0.4.PATCH1.RELEASE</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.4.PATCH1.RELEASE</version>
+  <version>1.0.4.PATCH2-SNAPSHOT</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.4.PATCH.BUILD-SNAPSHOT</version>
+  <version>1.0.4.PATCH1.RELEASE-SNAPSHOT</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4</version>
+      <version>1.4.01</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.4.BUILD-SNAPSHOT</version>
+  <version>1.0.4.PATCH.BUILD-SNAPSHOT</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>
@@ -247,4 +247,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <distributionManagement>
+    <repository>
+      <id>repository-releases</id>
+      <name>repository-releases</name>
+      <url>http://mvn-repo.kamodata.be/nexus/content/repositories/EVA-Maven2-Repository-Releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>repository-snapshots</id>
+      <name>repository-snapshots</name>
+      <url>http://mvn-repo.kamodata.be/nexus/content/repositories/EVA-Maven2-Repository-Snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/core/src/main/java/org/springframework/security/saml/parser/SAMLObject.java
+++ b/core/src/main/java/org/springframework/security/saml/parser/SAMLObject.java
@@ -63,7 +63,7 @@ public class SAMLObject<T extends XMLObject> extends SAMLBase<T, T> {
             if (serializedObject == null) {
                 serializedObject = XMLHelper.nodeToString(SAMLUtil.marshallMessage(getObject()));
             }
-            out.writeUTF((String) serializedObject);
+            out.writeObject(serializedObject);
         } catch (MessageEncodingException e) {
             log.error("Error serializing SAML object", e);
             throw new IOException("Error serializing SAML object: " + e.getMessage());
@@ -80,7 +80,7 @@ public class SAMLObject<T extends XMLObject> extends SAMLBase<T, T> {
      * @throws ClassNotFoundException class not found
      */
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        serializedObject = in.readUTF();
+        serializedObject = (String)in.readObject();
     }
 
     /**


### PR DESCRIPTION
Solution for issue https://github.com/spring-projects/spring-security-saml/issues/225

SAMLObject should use ObjectOutputStream.writeObject instead of writeUTF as writeUTF is limited in lenght (utflen < 0xFFFFL).
The writeObject method will still detect a String value and call writeUTF, but will use writeLongUTF if length is larger than 0xFFFFL.