### PR TITLE
SAMLCredential / SAMLObject greater than 64k (0xFFFFL) throws UTFDataFormatException

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/parser/SAMLObject.java
+++ b/core/src/main/java/org/springframework/security/saml/parser/SAMLObject.java
@@ -63,7 +63,7 @@ public class SAMLObject<T extends XMLObject> extends SAMLBase<T, T> {
             if (serializedObject == null) {
                 serializedObject = XMLHelper.nodeToString(SAMLUtil.marshallMessage(getObject()));
             }
-            out.writeUTF((String) serializedObject);
+            out.writeObject(serializedObject);
         } catch (MessageEncodingException e) {
             log.error("Error serializing SAML object", e);
             throw new IOException("Error serializing SAML object: " + e.getMessage());
@@ -80,7 +80,7 @@ public class SAMLObject<T extends XMLObject> extends SAMLBase<T, T> {
      * @throws ClassNotFoundException class not found
      */
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        serializedObject = in.readUTF();
+        serializedObject = (String)in.readObject();
     }
 
     /**


### PR DESCRIPTION
Solution for issue https://github.com/spring-projects/spring-security-saml/issues/225

SAMLObject should use ObjectOutputStream.writeObject instead of writeUTF as writeUTF is limited in lenght (utflen < 0xFFFFL).
The writeObject method will still detect a String value and call writeUTF, but will use writeLongUTF if length is larger than 0xFFFFL.