### PR TITLE
Remove RequestedAuthnContext element from default auth request

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/spi/Defaults.java
+++ b/core/src/main/java/org/springframework/security/saml/spi/Defaults.java
@@ -182,7 +182,6 @@ public class Defaults {
 			.setBinding(Binding.POST)
 			.setAssertionConsumerService(getACSFromSp(sp))
 			.setIssuer(new Issuer().setValue(sp.getEntityId()))
-			.setRequestedAuthenticationContext(exact)
 			.setDestination(idp.getIdentityProvider().getSingleSignOnService().get(0));
 		if (sp.getServiceProvider().isAuthnRequestsSigned()) {
 			request.setSigningKey(sp.getSigningKey(), sp.getAlgorithm(), sp.getDigest());


### PR DESCRIPTION
Hello,
I met an issue when integrating spring-security-saml with OpenAM. 
With default authentication request, the idp returns 'urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext'.

In the lastest code, default authentication request includes <saml2p:RequestedAuthnContext Comparison="exact" /> with no <saml:AuthnContextClassRef> or <saml:AuthnContextDeclRef>. 
According to the specification below, either  <saml:AuthnContextClassRef> or <saml:AuthnContextDeclRef> should be included when adding element RequestedAuthnContextl
https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf 

It seems in the default auth request, RequestedAuthenticationContext should be set to null instead of 'exact' to avoid incompatible issues with saml IDPs.

Best regards,
Perry