### PR TITLE
Don't append / when entityBaseURL ends with /

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
+++ b/core/src/main/java/org/springframework/security/saml/metadata/MetadataGenerator.java
@@ -502,7 +502,7 @@ public class MetadataGenerator {
 
         StringBuilder result = new StringBuilder();
         result.append(entityBaseURL);
-        if (!processingURL.startsWith("/")) {
+        if (!processingURL.startsWith("/") && entityBaseURL.endsWith("/")) {
             result.append("/");
         }
         result.append(processingURL);


### PR DESCRIPTION
If entityBaseURL ends with /, and processingURL starts with a / (as can easily happen due to reasonable configuration expectations), getServerURL will return an invalid URL. This change fixes the double-/ that is introduced.

Originally reported at https://github.com/spring-projects/spring-security-saml/pull/238 - I believe that PR was erroneously closed, from https://github.com/spring-projects/spring-security-saml/pull/238#issuecomment-404968399 :
> Our effort is focused on the v2 product in the `develop` branch

And that PR (as well as this one) are against the `develop` branch.