### PR TITLE
ID and index in AuthnRequests now accepted by Azure AD as IdP

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
+++ b/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
@@ -1169,7 +1169,8 @@ public class OpenSamlImplementation extends SpringSecuritySaml<OpenSamlImplement
 		auth.setForceAuthn(request.isForceAuth());
 		auth.setIsPassive(request.isPassive());
 		auth.setProtocolBinding(request.getBinding().toString());
-		auth.setAssertionConsumerServiceIndex(request.getAssertionConsumerService().getIndex());
+		// Azure AD as IdP will not accept index if protocol binding or AssertationCustomerServiceURL is set.
+//		auth.setAssertionConsumerServiceIndex(request.getAssertionConsumerService().getIndex());
 		auth.setAssertionConsumerServiceURL(request.getAssertionConsumerService().getLocation());
 		auth.setDestination(request.getDestination().getLocation());
 		auth.setNameIDPolicy(getNameIDPolicy(request.getNameIdPolicy()));


### PR DESCRIPTION
Working with Azure AD as a Service Provider uncovered a few issues with the AuthnRequest. The AssertationServiceProvider index was not accepted, as well as the ID didn't strictly follow the xs:ID format (when UUID.randomUUID() generated an ID starting with a digit rather than letter)