### PR TITLE
OpenSamlImplementation: Please get rid of the UnsupportedOperationException in the 'getSsoProvider' method

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
+++ b/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
@@ -638,7 +638,11 @@ public class OpenSamlImplementation extends SpringSecuritySaml<OpenSamlImplement
 	protected List<? extends Provider> getSsoProviders(EntityDescriptor descriptor) {
 		final List<SsoProvider> providers = new LinkedList<>();
 		for (RoleDescriptor roleDescriptor : descriptor.getRoleDescriptors()) {
-			providers.add(getSsoProvider(roleDescriptor));
+			SsoProvider ssoProvider = getSsoProvider(roleDescriptor);
+
+			if(ssoProvider != null) {
+				providers.add(ssoProvider);
+			}
 		}
 		return providers;
 	}
@@ -689,13 +693,8 @@ public class OpenSamlImplementation extends SpringSecuritySaml<OpenSamlImplement
 			return provider;
 		}
 		else {
-
+			return null; // instead of throwing an UnsupportedOperationException
 		}
-		throw new UnsupportedOperationException(
-			descriptor == null ?
-				null :
-				descriptor.getClass().getName()
-		);
 	}
 
 	protected List<Attribute> getRequestAttributes(SPSSODescriptor desc) {


### PR DESCRIPTION
The `UnsupportedOperationException` breaks the support for IdPs that have unsupported roledescriptors configured along with their metadata, e.g. the `AttributeAuthorityDescriptor`. For a reallife example please have a look into the [metadata of our corporate IdP](https://federation.basf.com/nidp/saml2/metadata). 

Either the exception should be captured [here](https://github.com/spring-projects/spring-security-saml/blob/c49fe770011c0fe24066f2b80c6b9f697ec82d0c/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java#L641), or - what I would personally prefer - it should be changed like attached to this PR.

Best,
Chris