### PR TITLE
Obvious: Rename the SamlResponseAuthenticationFilter to SamlAuthenticationResponseFilter

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/provider/service/authentication/SamlAuthenticationResponseFilter.java
+++ b/core/src/main/java/org/springframework/security/saml/provider/service/authentication/SamlAuthenticationResponseFilter.java
@@ -43,17 +43,17 @@ import org.apache.commons.logging.LogFactory;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.util.StringUtils.hasText;
 
-public class SamlResponseAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+public class SamlAuthenticationResponseFilter extends AbstractAuthenticationProcessingFilter {
 
-	private static Log logger = LogFactory.getLog(SamlResponseAuthenticationFilter.class);
+	private static Log logger = LogFactory.getLog(SamlAuthenticationResponseFilter.class);
 
 	private final SamlProviderProvisioning<ServiceProviderService> provisioning;
 
-	public SamlResponseAuthenticationFilter(SamlProviderProvisioning<ServiceProviderService> provisioning) {
+	public SamlAuthenticationResponseFilter(SamlProviderProvisioning<ServiceProviderService> provisioning) {
 		this(new SamlRequestMatcher(provisioning, "SSO"), provisioning);
 	}
 
-	private SamlResponseAuthenticationFilter(RequestMatcher requiresAuthenticationRequestMatcher,
+	private SamlAuthenticationResponseFilter(RequestMatcher requiresAuthenticationRequestMatcher,
 											 SamlProviderProvisioning<ServiceProviderService> provisioning) {
 		super(requiresAuthenticationRequestMatcher);
 		this.provisioning = provisioning;

--- a/core/src/main/java/org/springframework/security/saml/provider/service/config/SamlServiceProviderServerBeanConfiguration.java
+++ b/core/src/main/java/org/springframework/security/saml/provider/service/config/SamlServiceProviderServerBeanConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.security.saml.provider.service.SelectIdentityProvider
 import org.springframework.security.saml.provider.service.ServiceProviderMetadataFilter;
 import org.springframework.security.saml.provider.service.ServiceProviderService;
 import org.springframework.security.saml.provider.service.authentication.GenericErrorAuthenticationFailureHandler;
-import org.springframework.security.saml.provider.service.authentication.SamlResponseAuthenticationFilter;
+import org.springframework.security.saml.provider.service.authentication.SamlAuthenticationResponseFilter;
 import org.springframework.security.saml.provider.service.authentication.ServiceProviderLogoutHandler;
 import org.springframework.security.saml.provider.service.authentication.SimpleAuthenticationManager;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -60,8 +60,8 @@ public abstract class SamlServiceProviderServerBeanConfiguration
 	}
 
 	public Filter spAuthenticationResponseFilter() {
-		SamlResponseAuthenticationFilter authenticationFilter =
-			new SamlResponseAuthenticationFilter(getSamlProvisioning());
+		SamlAuthenticationResponseFilter authenticationFilter =
+			new SamlAuthenticationResponseFilter(getSamlProvisioning());
 		authenticationFilter.setAuthenticationManager(new SimpleAuthenticationManager());
 		authenticationFilter.setAuthenticationSuccessHandler(new SavedRequestAwareAuthenticationSuccessHandler());
 		authenticationFilter.setAuthenticationFailureHandler(new GenericErrorAuthenticationFailureHandler());


### PR DESCRIPTION
This is not a big thing but I would like to suggest to rename the `SamlResponseAutenticationFilter `to `SamlAuthenticationResponseFilter`. First of all to stick to the wording of the saml spec and secondly, it would make sense to use a similar name as for the request filter (`SamlAuthenticationRequestFilter`).

Please share your thoughts!

Chris