### PR TITLE
Ensure the Endpoint called is correct for authRequest's Binding

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/provider/service/SamlAuthenticationRequestFilter.java
+++ b/core/src/main/java/org/springframework/security/saml/provider/service/SamlAuthenticationRequestFilter.java
@@ -84,7 +84,7 @@ public class SamlAuthenticationRequestFilter extends SamlFilter<ServiceProviderS
 			//TODO - this can be better
 			Endpoint location = provider.getPreferredEndpoint(
 				idp.getIdentityProvider().getSingleSignOnService(),
-				Binding.REDIRECT,
+				authenticationRequest.getBinding(),
 				-1
 			);
 			sendAuthenticationRequest(provider, request, response, authenticationRequest, location);


### PR DESCRIPTION
While this doesn't fix the problem in HostedServiceProviderService.java:129 which always selects the first lists binding, it will at least ensure the generated AuthRequest is correct.