### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,12 @@ configure(allprojects) { project ->
 	repositories {
 		mavenCentral()
 		maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases/' }
-		maven { url 'http://repository.mulesoft.org/releases/'}
+		maven { url 'https://repository.mulesoft.org/releases/'}
 	}
 
 	ext.javadocLinks = [
-		"http://docs.oracle.com/javase/6/docs/api",
-		"http://docs.oracle.com/javaee/6/api",
+		"https://docs.oracle.com/javase/6/docs/api",
+		"https://docs.oracle.com/javaee/6/api",
 	] as String[]
 }
 
@@ -195,7 +195,7 @@ configure(rootProject) {
 		baseName = "spring-security-saml"
 		classifier = "docs"
 		description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://static.springframework.org/spring-security-saml/docs."
+			"for deployment at https://docs.spring.io/spring-security-saml/docs."
 
 		from (api) {
 			into "api"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,12 +10,12 @@
   <url>https://github.com/SpringSource/spring-security-saml</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/spring-security-saml</url>
+    <url>https://projects.spring.io/spring-security-saml</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -44,8 +44,8 @@
   <mailingLists>
     <mailingList>
       <name>Spring Security SAML Forum</name>
-      <post>http://forum.springsource.org/forumdisplay.php?86-SAML</post>
-      <archive>http://forum.springsource.org/forumdisplay.php?86-SAML</archive>
+      <post>http://forum.spring.io/forum/spring-projects/security/saml</post>
+      <archive>http://forum.spring.io/forum/spring-projects/security/saml</archive>
     </mailingList>
   </mailingLists>
   <scm>
@@ -55,7 +55,7 @@
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.springsource.org/browse/SES</url>
+    <url>https://jira.springsource.org/browse/SES</url>
   </issueManagement>
   <dependencies>
     <dependency>

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -41,12 +41,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/SpringSource/spring-security-saml"
 			organization {
 				name = "SpringSource"
-				url = "http://springsource.org/spring-security-saml"
+				url = "https://projects.spring.io/spring-security-saml"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}
@@ -79,13 +79,13 @@ def customizePom(pom, gradleProject) {
 			}
 			issueManagement {
 				system = "jira"
-				url = "http://jira.springsource.org/browse/SES"
+				url = "https://jira.springsource.org/browse/SES"
 			}
 			mailingLists {
 				mailingList {
 					name = "Spring Security SAML Forum"
-					post = "http://forum.springsource.org/forumdisplay.php?86-SAML"
-					archive = "http://forum.springsource.org/forumdisplay.php?86-SAML"
+					post = "http://forum.spring.io/forum/spring-projects/security/saml"
+					archive = "http://forum.spring.io/forum/spring-projects/security/saml"
 				}
 			}
 		}

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -11,20 +11,20 @@
   <url>https://github.com/SpringSource/spring-security-saml</url>
   <organization>
     <name>SpringSource</name>
-    <url>http://springsource.org/spring-security-saml</url>
+    <url>https://projects.spring.io/spring-security-saml</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
   <mailingLists>
     <mailingList>
       <name>Spring Security SAML Forum</name>
-      <post>http://forum.springsource.org/forumdisplay.php?86-SAML</post>
-      <archive>http://forum.springsource.org/forumdisplay.php?86-SAML</archive>
+      <post>http://forum.spring.io/forum/spring-projects/security/saml</post>
+      <archive>http://forum.spring.io/forum/spring-projects/security/saml</archive>
     </mailingList>
   </mailingLists>
   <developers>
@@ -51,7 +51,7 @@
   </contributors>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.springsource.org/browse/SES</url>
+    <url>https://jira.springsource.org/browse/SES</url>
   </issueManagement>
   <scm>
     <connection>scm:git:git://github.com/SpringSource/spring-security-saml</connection>
@@ -68,7 +68,7 @@
       </snapshots>
       <id>com.springsource.repository.maven.snapshot</id>
       <name>SpringSource Enterprise Bundle Maven Repository - SpringSource Snapshot Releases</name>
-      <url>http://maven.springframework.org/snapshot</url>
+      <url>https://maven.springframework.org/snapshot</url>
     </repository>
     <repository>
       <releases>
@@ -79,7 +79,7 @@
       </snapshots>
       <id>com.springsource.repository.maven.milestone</id>
       <name>Spring Framework Maven Milestone Releases (Maven Central Format)</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </repository>
   </repositories>
   <build>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://forum.springsource.org/forumdisplay.php?86-SAML (301) migrated to:  
  http://forum.spring.io/forum/spring-projects/security/saml ([https](https://forum.springsource.org/forumdisplay.php?86-SAML) result IllegalArgumentException).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repository.mulesoft.org/releases/ migrated to:  
  https://repository.mulesoft.org/releases/ ([https](https://repository.mulesoft.org/releases/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring-security-saml/docs (301) migrated to:  
  https://docs.spring.io/spring-security-saml/docs ([https](https://static.springframework.org/spring-security-saml/docs) result 301).
* http://jira.springsource.org/browse/SES migrated to:  
  https://jira.springsource.org/browse/SES ([https](https://jira.springsource.org/browse/SES) result 301).
* http://springsource.org/spring-security-saml (302) migrated to:  
  https://projects.spring.io/spring-security-saml ([https](https://springsource.org/spring-security-saml) result 301).
* http://docs.oracle.com/javaee/6/api migrated to:  
  https://docs.oracle.com/javaee/6/api ([https](https://docs.oracle.com/javaee/6/api) result 302).
* http://docs.oracle.com/javase/6/docs/api migrated to:  
  https://docs.oracle.com/javase/6/docs/api ([https](https://docs.oracle.com/javase/6/docs/api) result 302).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance