### PR TITLE
Reduce dependencies again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,8 @@ configure(allprojects) { project ->
 	ext.openSamlVersion = "2.6.6"
 	ext.openSamlXmlSec = "1.5.8"
 	ext.esapiVersion = "2.1.0.1"
-	ext.commonsFileuploadVersion = "1.3.3"
-	ext.commonsBeanUtilsVersion = "1.9.3"
-	ext.antisamyVersion = "1.5.7"
 	ext.xalanVersion = "2.7.2"
-	ext.xmlApisVersion = "1.4"
+	ext.xmlApisVersion = "1.4.01"
 	ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
 
 	apply plugin: "propdeps"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,9 +13,10 @@ dependencies {
 	compile(group: "org.opensaml", name: "opensaml", version: "$openSamlVersion") {
 		exclude(module: 'bcprov-jdk15on')
 		exclude(group: 'org.slf4j', module: 'log4j-over-slf4j')
+		exclude(group: 'org.slf4j', module: 'jcl-over-slf4j')
+		exclude(group: 'org.slf4j', module: 'jul-to-slf4j')
 		exclude(group: 'org.owasp.esapi', module: 'esapi')
 		exclude(group: 'ca.juliusdavies', module: 'not-yet-commons-ssl')
-		exclude(group: 'org.beanshell', module: 'beanshell')
 		exclude(group: "org.apache.velocity", module: 'velocity')
 	}
 	compile group: 'org.apache.velocity', name: 'velocity-engine-core', version: '2.0'
@@ -23,21 +24,23 @@ dependencies {
 	compile group:'org.bouncycastle', name:'bcpkix-jdk15on', version: "$bcpkixVersion"
 	compile group: 'org.apache.santuario', name: 'xmlsec', version: "$openSamlXmlSec"
 	compile (group:'org.owasp.esapi', name:'esapi', version: "$esapiVersion") {
+		exclude(group: 'org.beanshell', module: 'bsh-core')
 		exclude(group: 'xalan', module: 'xalan')
+		exclude(group: 'xom', module: 'xom')
+		exclude(group: 'log4j', module: 'log4j')
+		exclude(group: 'commons-configuration', module: 'commons-configuration')
 		exclude(group: 'commons-beanutils', module: 'commons-beanutils-core')
 		exclude(group: 'commons-fileupload', module: 'commons-fileupload')
 		exclude(group: 'org.owasp.antisamy', module: 'antisamy')
+		exclude(group: 'org.apache.xmlgraphics', module: 'batik-css')
 	}
-	compile group: 'commons-fileupload', name: 'commons-fileupload', version: "$commonsFileuploadVersion"
-	compile group: 'commons-beanutils', name: 'commons-beanutils', version: "$commonsBeanUtilsVersion"
-	compile group: 'org.owasp.antisamy', name: 'antisamy', version: "$antisamyVersion"
 	compile group: 'xalan', name: 'xalan', version:"$xalanVersion"
-	compile group: "com.narupley", name: "not-going-to-be-commons-ssl", version: "0.3.19"
+	compile group: "com.narupley", name: "not-going-to-be-commons-ssl", version: "0.3.20"
 	compile group: "xml-apis", name: "xml-apis", version: "$xmlApisVersion"
 
 	provided "javax.servlet:javax.servlet-api:3.0.1"
 
-	testCompile "org.slf4j:slf4j-log4j12:$slf4jVersion",
+	testCompile "org.slf4j:slf4j-simple:$slf4jVersion",
 		"org.easymock:easymock:3.5.1",
 		"junit:junit:4.12",
 		"commons-logging:commons-logging:1.2",

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.5.RELEASE</version>
+  <version>1.0.9.BUILD-SNAPSHOT</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>
@@ -61,19 +61,7 @@
     <dependency>
       <groupId>com.narupley</groupId>
       <artifactId>not-going-to-be-commons-ssl</artifactId>
-      <version>0.3.19</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.3.3</version>
+      <version>0.3.20</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -91,13 +79,13 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.58</version>
+      <version>1.60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.58</version>
+      <version>1.60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -111,8 +99,8 @@
           <groupId>org.apache.velocity</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>beanshell</artifactId>
-          <groupId>org.beanshell</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <groupId>org.slf4j</groupId>
         </exclusion>
         <exclusion>
           <artifactId>esapi</artifactId>
@@ -120,6 +108,10 @@
         </exclusion>
         <exclusion>
           <artifactId>log4j-over-slf4j</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jul-to-slf4j</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
         <exclusion>
@@ -133,17 +125,19 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.owasp.antisamy</groupId>
-      <artifactId>antisamy</artifactId>
-      <version>1.5.7</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>
       <version>2.1.0.1</version>
       <scope>compile</scope>
       <exclusions>
+        <exclusion>
+          <artifactId>commons-configuration</artifactId>
+          <groupId>commons-configuration</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>bsh-core</artifactId>
+          <groupId>org.beanshell</groupId>
+        </exclusion>
         <exclusion>
           <artifactId>xalan</artifactId>
           <groupId>xalan</groupId>
@@ -153,12 +147,24 @@
           <groupId>commons-fileupload</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>batik-css</artifactId>
+          <groupId>org.apache.xmlgraphics</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>xom</artifactId>
+          <groupId>xom</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>antisamy</artifactId>
           <groupId>org.owasp.antisamy</groupId>
         </exclusion>
         <exclusion>
           <artifactId>commons-beanutils-core</artifactId>
           <groupId>commons-beanutils</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -205,7 +211,7 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4</version>
+      <version>1.4.01</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -234,7 +240,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Most of those dependencies came with
006be6763b05ba3d040da24e177d7620f81d0b2f, which pulled esapi from a
transitive dependency of opensaml to a direct dependency, but
unfortunately didn't copy the list of excludes opensaml had in place.
This tries to revert that change.

Additionally, this excludes the mass of (optional) slf4j modules
included in all shibboleth-derived modules...

Fixes #237, #235, #144 and probably others