### PR TITLE
Fix NPE caused by null passphrase in SamlKeyStoreProvider

### DIFF
--- a/core/src/main/java/org/springframework/security/saml2/SamlKeyStoreProvider.java
+++ b/core/src/main/java/org/springframework/security/saml2/SamlKeyStoreProvider.java
@@ -50,7 +50,16 @@ public interface SamlKeyStoreProvider {
 
 			if (hasText(key.getPrivateKey())) {
 				PrivateKey pkey = X509Utils.readPrivateKey(key.getPrivateKey(), key.getPassphrase());
-				ks.setKeyEntry(key.getId(), pkey, key.getPassphrase().toCharArray(), new Certificate[]{certificate});
+				
+				char[] passphrase;
+				if(key.getPassphrase() != null) {
+				    passphrase = key.getPassphrase().toCharArray();
+				}
+				else {
+				    passphrase = new char[0];
+				}
+				
+				ks.setKeyEntry(key.getId(), pkey, passphrase, new Certificate[]{certificate});
 			}
 
 			return ks;


### PR DESCRIPTION
This PR fixes the `NullPointerException` that occurs when omitting the `passphrase` in the `application.yml` file. The workaround was to declare the `passphrase` with an empty String and thus the solution is to  detect the null passphrase and use an empty String internally.

This PR references issue #397 