### PR TITLE
Handled non successful status code response as SAMLStatusException

### DIFF
--- a/core/src/test/java/org/springframework/security/saml/websso/WebSSOProfileConsumerImplTest.java
+++ b/core/src/test/java/org/springframework/security/saml/websso/WebSSOProfileConsumerImplTest.java
@@ -28,6 +28,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.security.authentication.CredentialsExpiredException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.saml.SAMLCredential;
+import org.springframework.security.saml.SAMLStatusException;
 import org.springframework.security.saml.SAMLTestHelper;
 import org.springframework.security.saml.context.SAMLContextProvider;
 import org.springframework.security.saml.context.SAMLMessageContext;
@@ -137,6 +138,18 @@ public class WebSSOProfileConsumerImplTest {
         SAMLCredential samlCredential = profile.processAuthenticationResponse(messageContext);
         assertTrue(samlCredential.getAttributes().size() == 2);
     }
+
+	/**
+	 * Verifies that valid SAML response with an unsuccessful status code is correctly handled.
+	 *
+	 * @throws Exception error
+	 */
+	@Test(expected = SAMLStatusException.class)
+	public void testUnsuccessfulStatusResponse() throws Exception {
+		Response noPassiveStatusResponse = helper.getNoPassiveStatusResponse();
+		messageContext.setInboundSAMLMessage(noPassiveStatusResponse);
+		profile.processAuthenticationResponse(messageContext);
+	}
 
     /**
      * Verifies that processing of Response without authnStatement will fail.

--- a/core/src/test/java/org/springframework/security/saml/websso/WebSSOProfileTestHelper.java
+++ b/core/src/test/java/org/springframework/security/saml/websso/WebSSOProfileTestHelper.java
@@ -44,6 +44,23 @@ public class WebSSOProfileTestHelper {
         return response;
     }
 
+	public Response getNoPassiveStatusResponse() {
+		SAMLObjectBuilder<Response> builder = (SAMLObjectBuilder<Response>) builderFactory.getBuilder(Response.DEFAULT_ELEMENT_NAME);
+		Response response = builder.buildObject();
+
+		StatusCode subStatusCode = ((SAMLObjectBuilder<StatusCode>) builderFactory.getBuilder(StatusCode.DEFAULT_ELEMENT_NAME)).buildObject();
+		subStatusCode.setValue(StatusCode.NO_PASSIVE_URI);
+		StatusCode statusCode = ((SAMLObjectBuilder<StatusCode>) builderFactory.getBuilder(StatusCode.DEFAULT_ELEMENT_NAME)).buildObject();
+		statusCode.setValue(StatusCode.RESPONDER_URI);
+		statusCode.setStatusCode(subStatusCode);
+		Status status = ((SAMLObjectBuilder<Status>) builderFactory.getBuilder(Status.DEFAULT_ELEMENT_NAME)).buildObject();
+		status.setStatusCode(statusCode);
+		response.setStatus(status);
+		response.setIssueInstant(new DateTime());
+
+		return response;
+	}
+
     public SubjectConfirmation getBearerConfirmation() {
 
         SAMLObjectBuilder<SubjectConfirmation> confirmationBuilder = (SAMLObjectBuilder<SubjectConfirmation>) builderFactory.getBuilder(SubjectConfirmation.DEFAULT_ELEMENT_NAME);


### PR DESCRIPTION
When an unsuccesful status will be returned by the IDP a SAMLStatusException will be thrown.
In this way custom logic could be implemented in the AuthenticationFailureHandler based on the status code.