### PR TITLE
Scope the AuthnRequest before signing

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
+++ b/core/src/main/java/org/springframework/security/saml/spi/opensaml/OpenSamlImplementation.java
@@ -1211,10 +1211,10 @@ public class OpenSamlImplementation extends SpringSecuritySaml<OpenSamlImplement
 		auth.setNameIDPolicy(getNameIDPolicy(request.getNameIdPolicy()));
 		auth.setRequestedAuthnContext(getRequestedAuthenticationContext(request));
 		auth.setIssuer(toIssuer(request.getIssuer()));
+		auth.setScoping(getScoping(request.getScoping()));
 		if (request.getSigningKey() != null) {
 			this.signObject(auth, request.getSigningKey(), request.getAlgorithm(), request.getDigest());
 		}
-		auth.setScoping(getScoping(request.getScoping()));
 		return auth;
 	}
 


### PR DESCRIPTION
Issue https://github.com/spring-projects/spring-security-saml/issues/419
en subsequent pull-request
https://github.com/spring-projects/spring-security-saml/pull/420
introduced a bug. The optional scoping is applied after the authn
message is signed. This erases the signature in the saml-core libraries.

This pull request applies the signing before the signing.