### PR TITLE
change default for LogoutResponse

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/metadata/ExtendedMetadata.java
+++ b/core/src/main/java/org/springframework/security/saml/metadata/ExtendedMetadata.java
@@ -127,7 +127,7 @@ public class ExtendedMetadata implements Serializable, Cloneable {
     /**
      * Flag indicating whether incoming LogoutResposne messages must be authenticated.
      */
-    private boolean requireLogoutResponseSigned;
+    private boolean requireLogoutResponseSigned = true;
 
     /**
      * If true received artifactResolve messages will require a signature, sent artifactResolve will be signed.


### PR DESCRIPTION
according to
SAML2 spec http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf lines 1276-1277 logout messages must be signed in case of front channel.
see also https://github.com/spring-projects/spring-security-saml/issues/145