### PR TITLE
FIX OpenSAML version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ configure(allprojects) { project ->
 	ext.springSecurityVersion = "4.2.4.RELEASE"
 	ext.bcprovVersion = "1.60"
 	ext.bcpkixVersion = "1.60"
-	ext.openSamlVersion = "2.6.6"
+	ext.openSamlVersion = "2.6.4"
 	ext.openSamlXmlSec = "1.5.8"
 	ext.esapiVersion = "2.1.0.1"
 	ext.xalanVersion = "2.7.2"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.opensaml</groupId>
       <artifactId>opensaml</artifactId>
-      <version>2.6.6</version>
+      <version>2.6.4</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Fixes dependency error (not available in maven central) introduced with 006be67
Move to the last available version which is 2.6.4 instead of 2.6.6 as described in https://github.com/spring-projects/spring-security-saml/issues/237#issuecomment-383579590