### PR TITLE
Support PKCS#8 encrypted private key in Saml2KeyStoreProvider

### DIFF
--- a/core/src/test/java/saml/spi/ExamplePemKey.java
+++ b/core/src/test/java/saml/spi/ExamplePemKey.java
@@ -28,6 +28,43 @@ openssl x509 -passin pass:${DST}password -req -days 3650 -in server.csr -signkey
 
  */
 public enum ExamplePemKey {
+	PKCS8_ENCRYPTED_TEST_KEY(
+		"-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+			"MIICoTAbBgkqhkiG9w0BBQMwDgQIThAglp7gJIUCAggABIICgAi4ThqaZ3zy6oz6\n" +
+			"4ef75rKASLAoLbyMquY06zYUHQbrCliLvsq6h5MTcQWSyZdgBENA0e8EDP0yzXaq\n" +
+			"+kBgSLmyTdvs7yjG9v1pmMVVm3xGFy7UylTeJroKN53VHuX1D+VFfkgmik+dbKVb\n" +
+			"qLBqiJyEZbckbSvhkaEkklGss9FpoCeI0RiGNfFtMBcStWsXCPaBgrzOgzTEgaMZ\n" +
+			"5bnUW41woG7W2bDWo5nLoGtHdtUwfvGKsbsSgjS2ntoUM6S0twlrDOzGB/NfFl4V\n" +
+			"bPCwHVaJgTOBDDSCf7RVRrYQG42CA90DXLqCXZ/pe1ccb3ilShbsIKvhDKRB/sOL\n" +
+			"cYgjGg4qTO7SwHCr/bC7d3wUoh5XMMXRkycxKkAm6ty+sJn1jva6+m3N9+tUF6CM\n" +
+			"l5pLZxjkUNCAQUDwpR/MAtlv2FOJ9i/u+sj229pxWTZL1Vn5C/sRHFqMwQR2Awog\n" +
+			"0GLINRG/5olbwpgeaUJEvk9cacoWtdtKfEHoeorckysMPVkIrNaY0RAg51omNhkY\n" +
+			"ljmd5SwzcLzR/zB0GEGyRh609LKAU1n7sMewfywfRyOvY4R0rLezRVAaWFw6454q\n" +
+			"UEzTWgjTOdswuhMeK9jySZW7rHBwlTQy/Cer+QnkU2AJUZ0Ol202msluWgWQXI8W\n" +
+			"hjRHIHZzBOsCZVtlubaLfEYgl3xptltcebG1XQidNKBViuTvbrSZC+ILksglACGw\n" +
+			"NpCwbDYjIgF7Kt2niDbE6LqRejT2K4fQglSqrO0gks9hZFI12bxRYdOg1sWYO8u1\n" +
+			"WIWcPbyIQ1BkGp+SnO+m18SLPKfWJ5GV710/Ie9Gd4Ubhc/ioQzGhdnKSEXXDzTD\n" +
+			"aZ/keQ0=\n" +
+			"-----END ENCRYPTED PRIVATE KEY-----",
+		"-----BEGIN CERTIFICATE-----\n" +
+			"MIIChTCCAe4CCQDUctgDcqmqOzANBgkqhkiG9w0BAQsFADCBhjELMAkGA1UEBhMC\n" +
+			"VVMxEzARBgNVBAgMCldhc2hpbmd0b24xEjAQBgNVBAcMCVZhbmNvdXZlcjEdMBsG\n" +
+			"A1UECgwUU3ByaW5nIFNlY3VyaXR5IFNBTUwxDDAKBgNVBAsMA2lkcDEhMB8GA1UE\n" +
+			"AwwYaWRwLnNwcmluZy5zZWN1cml0eS5zYW1sMB4XDTE5MDkyNjA1MjcxNVoXDTI5\n" +
+			"MDkyMzA1MjcxNVowgYYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9u\n" +
+			"MRIwEAYDVQQHDAlWYW5jb3V2ZXIxHTAbBgNVBAoMFFNwcmluZyBTZWN1cml0eSBT\n" +
+			"QU1MMQwwCgYDVQQLDANpZHAxITAfBgNVBAMMGGlkcC5zcHJpbmcuc2VjdXJpdHku\n" +
+			"c2FtbDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA9qWQSrWX34LedCMs5A2j\n" +
+			"vF75y1swp7TuEDukirWYxlh8GGm8TZzLeWj9mLgoF/CRdee4LSP9eD/kmioYrug3\n" +
+			"p27BJtigTd5KD6ZmM7tLhhV4ITeOaPOCbwNkLbb/uUwBgU2crplRIx/IG9I4b6Op\n" +
+			"tF8lcKm2TGqeljz4t03HZXkCAwEAATANBgkqhkiG9w0BAQsFAAOBgQC4g8UyItjz\n" +
+			"fejgmRnA8WIgfitxyK78vONg7IB/6VQry23zXsT2VnWRa1zv3NI1qG6iuN8juUqZ\n" +
+			"FogKBWwGc/llHvmeH1myzmMuh2qkGDl3u1q/PwrnO9aA7iDQV3x/2MmkV3k/ZqxX\n" +
+			"SA8NVX1Z6ezCqISBrwmM3sYJz4WPbv08yw==\n" +
+			"-----END CERTIFICATE-----",
+		"changeit"
+	),
+
 	RSA_TEST_KEY(
 		"-----BEGIN RSA PRIVATE KEY-----\n" +
 			"MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5\n" +

--- a/core/src/test/java/saml/spi/Saml2KeyStoreProviderTests.java
+++ b/core/src/test/java/saml/spi/Saml2KeyStoreProviderTests.java
@@ -16,6 +16,7 @@
  */
 package saml.spi;
 
+import java.security.*;
 import java.time.Clock;
 
 import org.springframework.security.saml2.spi.Saml2KeyStoreProvider;
@@ -24,11 +25,15 @@ import org.springframework.security.saml2.spi.opensaml.OpenSaml2Implementation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.saml2.spi.ExamplePemKey.IDP_RSA_KEY;
 import static org.springframework.security.saml2.spi.ExamplePemKey.RSA_TEST_KEY;
 import static org.springframework.security.saml2.spi.ExamplePemKey.SP_RSA_KEY;
+import static saml.spi.ExamplePemKey.PKCS8_ENCRYPTED_TEST_KEY;
 
 public class Saml2KeyStoreProviderTests {
+
+	private static final String TEST_ALIAS = "alias";
 
 	@BeforeAll
 	public static void initProvider() {
@@ -48,4 +53,13 @@ public class Saml2KeyStoreProviderTests {
 	public void test_sp_1024() {
 		new Saml2KeyStoreProvider(){}.getKeyStore(SP_RSA_KEY.getSimpleKey("alias"));
 	}
+
+	@Test
+	public void test_pkcs8_encrypted() throws KeyStoreException, UnrecoverableKeyException, NoSuchAlgorithmException {
+		KeyStore ks = new Saml2KeyStoreProvider(){}.getKeyStore(PKCS8_ENCRYPTED_TEST_KEY.getSimpleKey(TEST_ALIAS));
+		Key info = ks.getKey(TEST_ALIAS, PKCS8_ENCRYPTED_TEST_KEY.getPassphrase().toCharArray());
+		assertTrue(ks.containsAlias(TEST_ALIAS));
+		assertTrue(info != null && info.getFormat().equals("PKCS#8"));
+	}
+
 }


### PR DESCRIPTION
### Support PKCS#8 encrypted private key in Saml2KeyStoreProvider 

### Details
`X509Utilities.readPrivateKey()` currently only supports `PEMEncryptedKeyPair`. A `PKCS8EncryptedPrivateKeyInfo` will result into `ClassCastException`.    

Thus, providing the support for type **PKCS8EncryptedPrivateKeyInfo**.   
- Fixes gh-314   
- CLA signed

### How has this been tested
- Tested using Unit test.

### Others 
- In the [CONTRIBUTING.md](https://github.com/spring-projects/spring-security-saml/blob/develop/CONTRIBUTING.md#create-your-branch-from-master), it suggested to make PR from `master`. However, one of the file doesn't exist in that branch. Therefore, targeted to `develop-3.0`. 
- Let me know if target branch is inappropriate. 