### PR TITLE
spring-projects/spring-security-saml#233

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/metadata/MetadataManager.java
+++ b/core/src/main/java/org/springframework/security/saml/metadata/MetadataManager.java
@@ -640,11 +640,13 @@ public class MetadataManager extends ChainingMetadataProvider implements Extende
 
         // Resolve allowed certificates to build the anchors
         List<X509Certificate> certificates = new LinkedList<X509Certificate>();
+        Set<String> trustedSubjectDns = new HashSet<String>();
         for (String key : trustedKeys) {
             log.debug("Adding PKIX trust anchor {} for metadata verification of provider {}", key, provider);
             X509Certificate certificate = keyManager.getCertificate(key);
             if (certificate != null) {
                 certificates.add(certificate);
+                trustedSubjectDns.add( certificate.getSubjectDN().getName() );
             } else {
                 log.warn("Cannot construct PKIX trust anchor for key with alias {} for provider {}, key isn't included in the keystore", key, provider);
             }
@@ -652,7 +654,7 @@ public class MetadataManager extends ChainingMetadataProvider implements Extende
 
         List<PKIXValidationInformation> info = new LinkedList<PKIXValidationInformation>();
         info.add(new BasicPKIXValidationInformation(certificates, null, 4));
-        return new StaticPKIXValidationInformationResolver(info, trustedNames) {
+        return new StaticPKIXValidationInformationResolver(info, trustedNames != null ? trustedNames : trustedSubjectDns) {
             @Override
             public Set<String> resolveTrustedNames(CriteriaSet criteriaSet)
                 throws SecurityException, UnsupportedOperationException {

--- a/core/src/main/java/org/springframework/security/saml/trust/httpclient/TLSProtocolSocketFactory.java
+++ b/core/src/main/java/org/springframework/security/saml/trust/httpclient/TLSProtocolSocketFactory.java
@@ -26,10 +26,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Socket factory can be used with HTTP Client for creation of SSL/TLS sockets. Implementation uses internal KeyManager
@@ -136,14 +133,17 @@ public class TLSProtocolSocketFactory implements SecureProtocolSocketFactory {
 
         // Resolve allowed certificates to build the anchors
         List<X509Certificate> certificates = new ArrayList<X509Certificate>(trustedKeys.size());
+        Set<String> subjectDNs = new HashSet<String>(trustedKeys.size());
         for (String key : trustedKeys) {
             log.debug("Adding PKIX trust anchor {} for SSL/TLS verification {}", key);
-            certificates.add(keyManager.getCertificate(key));
+            X509Certificate cert = keyManager.getCertificate(key);
+            certificates.add(cert);
+            subjectDNs.add(cert.getSubjectDN().getName());
         }
 
         List<PKIXValidationInformation> info = new LinkedList<PKIXValidationInformation>();
         info.add(new BasicPKIXValidationInformation(certificates, null, 4));
-        return new StaticPKIXValidationInformationResolver(info, null);
+        return new StaticPKIXValidationInformationResolver(info, subjectDNs);
 
     }
 


### PR DESCRIPTION
Provide fixes to name verification of certs for trust engine when using
TLSProtocolConfigurer and TLSProtocolSocketFactory which would always send a null
in for trustedKey names.  This caused the algorithm in BasicX509CredentialNameEvaluator
to always reject any key over HTTPS regardless if that cert was imported into
the keystore properly.