### PR TITLE
Change auth permit scope of SamlServiceProviderSecurityConfiguration.

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/provider/service/config/SamlServiceProviderSecurityConfiguration.java
+++ b/core/src/main/java/org/springframework/security/saml/provider/service/config/SamlServiceProviderSecurityConfiguration.java
@@ -53,7 +53,7 @@ public abstract class SamlServiceProviderSecurityConfiguration
 			.antMatcher(filterChainPattern)
 			.csrf().disable()
 			.authorizeRequests()
-			.antMatchers("/**").permitAll();
+			.antMatchers(filterChainPattern).permitAll();
 
 
 		http


### PR DESCRIPTION
* SamlServiceProviderSecurityConfiguration config allows auth permit scope for all url. But this behavior is not intended by the end user.