### PR TITLE
Fix degrade: SES-154 Changing maxAuthenticationAge to long in order to support values longer than 24 days

### DIFF
--- a/core/src/main/java/org/springframework/security/saml/spi/DefaultValidator.java
+++ b/core/src/main/java/org/springframework/security/saml/spi/DefaultValidator.java
@@ -66,7 +66,7 @@ public class DefaultValidator implements SamlValidator {
 	private SpringSecuritySaml implementation;
 	private int responseSkewTimeMillis = 1000 * 60 * 2; //two minutes
 	private boolean allowUnsolicitedResponses = true;
-	private int maxAuthenticationAgeMillis = 1000 * 60 * 60 * 24; //24 hours
+	private long maxAuthenticationAgeMillis = 1000 * 60 * 60 * 24; //24 hours
 	private Clock time = Clock.systemUTC();
 
 	public DefaultValidator(SpringSecuritySaml implementation) {
@@ -447,13 +447,13 @@ public class DefaultValidator implements SamlValidator {
 		return new ValidationResult(response);
 	}
 
-	protected boolean isDateTimeSkewValid(int skewMillis, int forwardMillis, DateTime time) {
+	protected boolean isDateTimeSkewValid(int skewMillis, long forwardMillis, DateTime time) {
 		if (time == null) {
 			return false;
 		}
 		final DateTime reference = new DateTime();
 		final Interval validTimeInterval = new Interval(
-			reference.minusMillis(skewMillis + forwardMillis),
+			new DateTime(Long.valueOf(reference.getMillis() - (skewMillis + forwardMillis))),
 			reference.plusMillis(skewMillis)
 		);
 		return validTimeInterval.contains(time);
@@ -516,8 +516,13 @@ public class DefaultValidator implements SamlValidator {
 		return null;
 	}
 
-	public int getMaxAuthenticationAgeMillis() {
+	public long getMaxAuthenticationAgeMillis() {
 		return maxAuthenticationAgeMillis;
+	}
+
+	public DefaultValidator setMaxAuthenticationAgeMillis(long maxAuthenticationAgeMillis) {
+		this.maxAuthenticationAgeMillis = maxAuthenticationAgeMillis;
+		return this;
 	}
 
 	public Clock time() {
@@ -543,10 +548,6 @@ public class DefaultValidator implements SamlValidator {
 			return uri.substring(0, queryStringIndex);
 		}
 		return uri;
-	}
-
-	public void setMaxAuthenticationAgeMillis(int maxAuthenticationAgeMillis) {
-		this.maxAuthenticationAgeMillis = maxAuthenticationAgeMillis;
 	}
 
 


### PR DESCRIPTION
In the past, I have observed that https://github.com/spring-projects/spring-security-saml/issues/132 issues are resolved in https://github.com/spring-projects/spring-security-saml/commit/1a74cc48d0c5b04071431830e5e56ea55250f9e2#diff-6c2901d8d416501d4f0a3e6321ed0a5d in this project.

However, now it appears that the features supported by version1 have been degraded as version2.
Therefore, I fixed this issue in this PR.