### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 version=1.0.11.BUILD-SNAPSHOT
 maxParallelForks=1
+org.gradle.caching = true
+org.gradle.parallel = true
+org.gradle.configureondemand = true


### PR DESCRIPTION

[Parallel builds](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:parallel_execution). This project contains multiple modules. Parallel builds can improve the build speed by executing tasks in parallel. We can enable this feature by setting `org.gradle.parallel=true`.

[Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand). Configuration on demand tells Gradle to configure modules that only are relevant to the requested tasks instead of configuring all of them. We can enable this feature by setting `org.gradle.configureondemand=true`.

[gradle caching](https://docs.gradle.org/current/userguide/build_cache.html). Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting `org.gradle.caching=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
